### PR TITLE
Response as a setting

### DIFF
--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -11,11 +11,8 @@ from helga import settings
 
 
 REQUEST_TEMPLATE = '{}videos?id={}&key={}&part=snippet,statistics,contentDetails'
-RESPONSE_TEMPLATE = ("Title: {}, poster: {}, date: {}, views: {}, likes: {}, "
-                     "dislikes: {}, duration: {}")
-KEY_MISSING_TOKEN = 'NO_API_KEY'
+RESPONSE_TEMPLATE = ("{} by {} [{}]")
 API_ROOT = 'https://www.googleapis.com/youtube/v3/'
-API_KEY = getattr(settings, 'YOUTUBE_DATA_API_KEY', KEY_MISSING_TOKEN)
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
 
@@ -26,8 +23,12 @@ def youtube_meta(client, channel, nick, message, match):
     if API_KEY == KEY_MISSING_TOKEN:
         return 'You must set YOUTUBE_DATA_API_KEY in settings!'
     identifier = match[0]
-    request_url = REQUEST_TEMPLATE.format(API_ROOT, identifier, API_KEY)
-    response = requests.get(request_url)
+    params = {
+        'id': identifier,
+        'key': getattr(settings, 'YOUTUBE_DATA_API_KEY', 'NO_API_KEY'),
+    }
+    response = requests.get(API_ROOT, params=params)
+
     if response.status_code != 200:
         return 'Error in response, ' + str(response.status_code) + ' for identifier: ' + identifier
     try:
@@ -35,6 +36,7 @@ def youtube_meta(client, channel, nick, message, match):
     except:
         print('Exception requesting info for identifier: ' + identifier)
         traceback.print_exc()
+
     title = data['snippet']['title']
     poster = data['snippet']['channelTitle']
     date = str(parse_date(data['snippet']['publishedAt']))
@@ -42,7 +44,7 @@ def youtube_meta(client, channel, nick, message, match):
     likes = data['statistics']['likeCount']
     dislikes = data['statistics']['dislikeCount']
     duration = parse_duration(data['contentDetails']['duration'])
-    return RESPONSE_TEMPLATE.format(title, poster, date, views, likes, dislikes, duration)
+    return RESPONSE_TEMPLATE.format(title, poster, duration)
 
 
 def parse_duration(duration):

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -14,7 +14,6 @@ API_KEY = getattr(settings, 'YOUTUBE_DATA_API_KEY', False)
 API_ROOT = 'https://www.googleapis.com/youtube/v3/videos'
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
-REQUEST_TEMPLATE = '{}videos?id={}&key={}&part=snippet,statistics,contentDetails'
 RESPONSE_TEMPLATE = ("{} by {} [{}]")
 RESPONSE_TEMPLATE = getattr(settings, 'YOUTUBE_META_RESPONSE',
                             ("Title: {title}, poster: {poster}, date: {date},"

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -12,7 +12,7 @@ from helga import settings
 
 REQUEST_TEMPLATE = '{}videos?id={}&key={}&part=snippet,statistics,contentDetails'
 RESPONSE_TEMPLATE = ("{} by {} [{}]")
-API_ROOT = 'https://www.googleapis.com/youtube/v3/'
+API_ROOT = 'https://www.googleapis.com/youtube/v3/videos'
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
 
@@ -26,6 +26,7 @@ def youtube_meta(client, channel, nick, message, match):
     params = {
         'id': identifier,
         'key': getattr(settings, 'YOUTUBE_DATA_API_KEY', 'NO_API_KEY'),
+        'part': 'snippet,statistics,contentDetails',
     }
     response = requests.get(API_ROOT, params=params)
 

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -11,7 +11,6 @@ from helga import settings
 
 
 REQUEST_TEMPLATE = '{}videos?id={}&key={}&part=snippet,statistics,contentDetails'
-RESPONSE_TEMPLATE = ("{} by {} [{}]")
 API_ROOT = 'https://www.googleapis.com/youtube/v3/videos'
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
@@ -45,7 +44,7 @@ def youtube_meta(client, channel, nick, message, match):
     likes = data['statistics']['likeCount']
     dislikes = data['statistics']['dislikeCount']
     duration = parse_duration(data['contentDetails']['duration'])
-    return RESPONSE_TEMPLATE.format(title, poster, duration)
+    return u'{} by {} [{}]'.format(title, poster, duration).encode('utf-8').strip()
 
 
 def parse_duration(duration):

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -14,7 +14,6 @@ API_KEY = getattr(settings, 'YOUTUBE_DATA_API_KEY', False)
 API_ROOT = 'https://www.googleapis.com/youtube/v3/videos'
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
-RESPONSE_TEMPLATE = ("{} by {} [{}]")
 RESPONSE_TEMPLATE = getattr(settings, 'YOUTUBE_META_RESPONSE',
                             ("Title: {title}, poster: {poster}, date: {date},"
                              "views: {views}, likes: {likes}, dislikes: {dislikes},"

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -11,6 +11,8 @@ from helga import settings
 
 
 REQUEST_TEMPLATE = '{}videos?id={}&key={}&part=snippet,statistics,contentDetails'
+RESPONSE_TEMPLATE = ("{} by {} [{}]")
+API_KEY = getattr(settings, 'YOUTUBE_DATA_API_KEY', False)
 API_ROOT = 'https://www.googleapis.com/youtube/v3/videos'
 DURATION_REGEX = r'P(?P<days>[0-9]+D)?T(?P<hours>[0-9]+H)?(?P<minutes>[0-9]+M)?(?P<seconds>[0-9]+S)?'
 NON_DECIMAL = re.compile(r'[^\d]+')
@@ -19,12 +21,12 @@ NON_DECIMAL = re.compile(r'[^\d]+')
 @match(r'(?:youtu\.be/|youtube\.com/watch\?(?:(?:\S+)&)?v=)([-\w]+)')
 def youtube_meta(client, channel, nick, message, match):
     """ Return meta information about a video """
-    if API_KEY == KEY_MISSING_TOKEN:
+    if not API_KEY:
         return 'You must set YOUTUBE_DATA_API_KEY in settings!'
     identifier = match[0]
     params = {
         'id': identifier,
-        'key': getattr(settings, 'YOUTUBE_DATA_API_KEY', 'NO_API_KEY'),
+        'key': API_KEY,
         'part': 'snippet,statistics,contentDetails',
     }
     response = requests.get(API_ROOT, params=params)
@@ -44,7 +46,7 @@ def youtube_meta(client, channel, nick, message, match):
     likes = data['statistics']['likeCount']
     dislikes = data['statistics']['dislikeCount']
     duration = parse_duration(data['contentDetails']['duration'])
-    return u'\'{}\' by {} [{}]'.format(title, poster, duration).encode('utf-8').strip()
+    return RESPONSE_TEMPLATE.format(title, poster, duration)
 
 
 def parse_duration(duration):

--- a/helga_youtube_meta/plugin.py
+++ b/helga_youtube_meta/plugin.py
@@ -44,7 +44,7 @@ def youtube_meta(client, channel, nick, message, match):
     likes = data['statistics']['likeCount']
     dislikes = data['statistics']['dislikeCount']
     duration = parse_duration(data['contentDetails']['duration'])
-    return u'{} by {} [{}]'.format(title, poster, duration).encode('utf-8').strip()
+    return u'\'{}\' by {} [{}]'.format(title, poster, duration).encode('utf-8').strip()
 
 
 def parse_duration(duration):


### PR DESCRIPTION
This allows the format string that is used as the plugins output can be set as a setting. To facilitate, we're passing the data dict to format() using kwargs, so that any subset of said data can be used.

Example override: https://github.com/bigjust/nintenbots/blob/master/files/helga/settings.d/900_youtube.py